### PR TITLE
chore: update dotenv package version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
-        "dotenv": "^16.4.5",
+        "dotenv": "^16.4.7",
         "express": "^5.0.1",
         "jsonwebtoken": "^9.0.0",
         "knex": "^2.4.2",
@@ -3675,9 +3675,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.4.5",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
-      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
-    "dotenv": "^16.4.5",
+    "dotenv": "^16.4.7",
     "express": "^5.0.1",
     "jsonwebtoken": "^9.0.0",
     "knex": "^2.4.2",


### PR DESCRIPTION
### Descripción
Actualización de la versión del paquete `dotenv` para mantener el proyecto actualizado con las dependencias más recientes.

### Cambios realizados
- Se actualizó la versión de `dotenv` en `package.json` y `package-lock.json` (o yarn.lock si usas yarn).

### Motivo
Mantener el proyecto alineado con versiones estables y seguras de sus dependencias.

### Checklist
- [x] Proyecto corre correctamente después de la actualización
- [x] No se detectan cambios de comportamiento en el entorno local